### PR TITLE
Milestone 5. Controllers specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,7 @@ group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   # gem 'debug', platforms: %i[mri mingw x64_mingw]
   gem 'rspec-rails'
+  gem 'rails-controller-testing'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -54,8 +54,8 @@ gem 'rubocop', '>= 1.0', '< 2.0'
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   # gem 'debug', platforms: %i[mri mingw x64_mingw]
-  gem 'rspec-rails'
   gem 'rails-controller-testing'
+  gem 'rspec-rails'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,6 +152,10 @@ GEM
       activesupport (= 7.0.4)
       bundler (>= 1.15.0)
       railties (= 7.0.4)
+    rails-controller-testing (1.0.5)
+      actionpack (>= 5.0.1.rc1)
+      actionview (>= 5.0.1.rc1)
+      activesupport (>= 5.0.1.rc1)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -251,6 +255,7 @@ DEPENDENCIES
   pg (~> 1.1)
   puma (~> 5.0)
   rails (~> 7.0.4)
+  rails-controller-testing
   rspec-rails
   rubocop (>= 1.0, < 2.0)
   selenium-webdriver

--- a/spec/requests/posts_spec.rb
+++ b/spec/requests/posts_spec.rb
@@ -22,10 +22,22 @@ RSpec.describe 'Posts', type: :request do
     end
   end
 
-  describe 'GET /show' do
+  describe 'GET /users/:id/posts/:id/' do
+    before(:example) do
+      post = Post.create(title: 'My first post', author: @user, text: 'Text of my first post')
+      get "/users/#{@id}/posts/#{post.id}/"
+    end
+
     it 'returns http success' do
-      get '/posts/show'
       expect(response).to have_http_status(:success)
+    end
+
+    it 'renders the correct template' do
+      expect(response).to render_template(:show)
+    end
+
+    it 'includes the correct placeholder text in its body' do
+      expect(response.body).to include('<div class="detailed_post">')
     end
   end
 end

--- a/spec/requests/posts_spec.rb
+++ b/spec/requests/posts_spec.rb
@@ -1,10 +1,24 @@
 require 'rails_helper'
 
 RSpec.describe 'Posts', type: :request do
-  describe 'GET /index' do
+  before(:each) do
+    @user = User.create(name: 'David')
+    @id = @user.id
+  end
+
+  describe 'GET /users/:id/posts/' do
+    before(:example) { get "/users/#{@id}/posts/" }
+
     it 'returns http success' do
-      get '/posts/index'
       expect(response).to have_http_status(:success)
+    end
+
+    it 'renders the correct template' do
+      expect(response).to render_template(:index)
+    end
+
+    it 'includes the correct placeholder text in its body' do
+      expect(response.body).to include('<h1>Posts</h1>')
     end
   end
 

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'Users', type: :request do
   describe 'GET /' do
-    before(:example) { get '/'}
+    before(:example) { get '/' }
 
     it 'returns http success' do
       expect(response).to have_http_status(:success)
@@ -17,10 +17,22 @@ RSpec.describe 'Users', type: :request do
     end
   end
 
-  describe 'GET /show' do
+  describe 'GET users/:id/' do
+    before(:example) do
+      user = User.create(name: 'David')
+      get "/users/#{user.id}/"
+    end
+
     it 'returns http success' do
-      get '/users/show'
       expect(response).to have_http_status(:success)
+    end
+
+    it 'renders the correct template' do
+      expect(response).to render_template(:show)
+    end
+
+    it 'includes the correct placeholder text in its body' do
+      expect(response.body).to include('<h1>User#Name placeholder</h1>')
     end
   end
 end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -1,10 +1,19 @@
 require 'rails_helper'
 
 RSpec.describe 'Users', type: :request do
-  describe 'GET /index' do
+  describe 'GET /' do
+    before(:example) { get '/'}
+
     it 'returns http success' do
-      get '/users/index'
       expect(response).to have_http_status(:success)
+    end
+
+    it 'renders the correct template' do
+      expect(response).to render_template(:index)
+    end
+
+    it 'includes the correct placeholder text in its body' do
+      expect(response.body).to include('<h1>Users</h1>')
     end
   end
 


### PR DESCRIPTION
# Milestone 5. Controllers specs 🎉

For this milestone, the following features have been implemented:

## New Gem installed

- `rails-controller-testing` => Allows to use the matcher `render_template` for controller testing

## User controller tests

### GET /
- returns http success
- renders the correct template
- includes the correct placeholder text in its body

### GET users/:id/
- returns http success
- renders the correct template
- includes the correct placeholder text in its body 

## Post controller tests

### GET /users/:id/posts/
- returns http success
- renders the correct template
- includes the correct placeholder text in its body

### GET /users/:id/posts/:id/
- returns http success
- renders the correct template
- includes the correct placeholder text in its body

## Pending Tests

The following tests were included when generating the controllers and views. These tests will be removed on the next milestone if they are not needed.

### Helper tests
- PostsHelper
- UsersHelper

### Views tests
- posts/index.html.erb
- posts/show.html.erb
- users/index.html.erb
- users/show.html.erb